### PR TITLE
Fix build by updating NUnit test init attribute

### DIFF
--- a/TLSharp.Tests.NUnit/Test.cs
+++ b/TLSharp.Tests.NUnit/Test.cs
@@ -9,7 +9,7 @@ namespace TLSharp.Tests
     [TestFixture]
     public class TLSharpTestsNUnit : TLSharpTests
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Init()
         {
             base.Init(o => Assert.IsNotNull(o), b => Assert.IsTrue(b));


### PR DESCRIPTION
Something has changed with Nunit 3.x. TestFixtureSetUp is one of them. 